### PR TITLE
Wercker Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "nunjucks": "gulp nunjucks",
     "build": "gulp build",
     "watch": "gulp watch",
-    "publish": "gulp build && git add dist && git commit && git subtree push --prefix dist/ origin gh-pages --squash && git push origin master"
+    "publish": "git subtree push --prefix dist/ origin gh-pages && git push origin master"
   },
   "repository": {
     "type": "git",

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,20 @@
+box: node
+
+build:
+  steps:
+    - npm-install
+    - script:
+      name: build
+      code: npm run build
+
+deploy:
+  steps:
+    - lukevivier/gh-pages:
+      token: $GITHUB_TOKEN
+      domain: keita-lab.jp
+      basedir: dist
+  after-steps:
+    - wantedly/pretty-slack-notify:
+      webhook_url: $SLACK_WEBHOOK_URL
+      channel: website
+      username: cibot


### PR DESCRIPTION
masterにpushするとwerckerというサービスが`dist/`以下をgh-pagesに自動でpushします．
SlackのtokenとGithubのtokenは僕のユーザーで取得していますが放置したとしても特に問題は無いはずです．
